### PR TITLE
Version updated to v0.7.1

### DIFF
--- a/cf_teams/main.py
+++ b/cf_teams/main.py
@@ -92,6 +92,7 @@ def registration_delete():
     update_guiview(get_status(), 0)
 
 
+update_thread_pause = False
 def get_acc_type():
     account = subprocess.getoutput("warp-cli registration show")
     return (account.find("Team") > -1)
@@ -443,12 +444,13 @@ class TestThreading(object):
 
     def run(self,acc_label):
         while True:
-            status = get_status()
-            if status == "UP":
-                stats_label_update()
-            if self.status_oldval != status:
-                self.status_oldval = status
-                update_guiview(status, 0)
+            if update_thread_pause == False:
+                status = get_status()
+                if status == "UP":
+                    stats_label_update()
+                if self.status_oldval != status:
+                    self.status_oldval = status
+                    update_guiview(status, 0)
             time.sleep(self.interval)
 
 ################################################################################

--- a/cf_teams/main.py
+++ b/cf_teams/main.py
@@ -290,7 +290,7 @@ root.resizable(False,False)
 root.iconphoto(True,appicon_init)
 root.config(bg = bgcolor)
 
-lbl = Label(root, text = "GUI v0.7", fg = "DimGray", bg = bgcolor,
+lbl = Label(root, text = "GUI v0.7.1", fg = "DimGray", bg = bgcolor,
     font = ("Arial", 12), pady=10, padx=10)
 lbl.grid()
 lbl.place(relx=0.0, rely=1.0, anchor='sw')

--- a/cf_teams/main.py
+++ b/cf_teams/main.py
@@ -451,9 +451,6 @@ class TestThreading(object):
                 update_guiview(status, 0)
             time.sleep(self.interval)
 
-
-root.tr = TestThreading()
-
 ################################################################################
 
 frame = Frame(root, bg = bgcolor)
@@ -471,4 +468,5 @@ slogan.pack(side=BOTTOM, pady=10, padx=(10,10))
 ################################################################################
 
 root.config(menu=menubar)
+root.tr = TestThreading()
 root.mainloop()


### PR DESCRIPTION
The menu 'WARP Session Renew' has been implemented in substitution of slide button for quick registration. Reasons for this change explained into the related commit. The 'WARP Session Renew' checks for the current state (connected or not) and after having delete and registered a new WARP session, it brings the connection UP or not accordingly with the previous state.